### PR TITLE
Add nav/tramp-to-term

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ keybindings or helper functions to interact with this process buffer.
   :init-script ("cd project-path" "bundle exec rails c") ;; (4)
   )
 
-;; M-x: nav/rails-console-production-pop-to-buffer
+;; M-x: nav/production-console-pop-to-buffer
 ;; will open a new buffer to a production rails console
 
 (nav/defterminal foobar-ipython
@@ -102,7 +102,7 @@ working with remote terminals. Just need to provide the
 
 Another way to create a persistent-terminal without a `defterminal`
 profile is via the function `nav/persistent-term`. It's important to
-note that the `:program-args` paramenter will not work when using
+note that the `:program-args` parameter will not work when using
 persistent terminals, this is a limitation of the GNU Screen
 program. You can however trick this by creating a custom bash script
 with all the arguments you need and call that script from navorski

--- a/navorski.el
+++ b/navorski.el
@@ -4,7 +4,7 @@
 ;; Copyright (C) 2013 Birdseye Software, Inc.
 
 ;; Author: Roman Gonzalez <romanandreg@gmail.com>, Tavis Rudd <tavis@birdseye-sw.com>
-;; Mantainer: Roman Gonzalez <romanandreg@gmail.com>
+;; Maintainer: Roman Gonzalez <romanandreg@gmail.com>
 ;; Version: 0.2.6
 ;; Package-Requires: ((s "1.9.0") (dash "1.5.0") (multi-term "0.8.14"))
 ;; Keywords: terminal

--- a/navorski.el
+++ b/navorski.el
@@ -749,6 +749,17 @@ a GNU screen session name."
     (-navorski-remote-term-setup-tramp-string)
     "\n")))
 
+;;;###autoload
+(defun nav/tramp-to-term ()
+  "Creates a terminal from the current TRAMP buffer."
+  (interactive)
+  (require 'tramp)
+  (with-parsed-tramp-file-name default-directory nil
+      (nav/remote-term
+       `((:kill-buffer-on-stop . t)
+         (:remote-host . ,(concat user "@" host))
+         (:program-args . (,(concat "-c 'cd " localname " && bash -l'")))))))
+
 ;; End:
 (provide 'navorski)
 ;;; navorski.el ends here

--- a/navorski.el
+++ b/navorski.el
@@ -149,9 +149,7 @@
         ("" . term-send-backward-word)
         ("" . term-send-forward-word)
         ("M-d" . term-send-forward-kill-word)
-        ("C-y" . -navorski-term-yank)
-
-        ))
+        ("C-y" . -navorski-term-yank)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Utils
@@ -370,13 +368,13 @@
 
 (defun -navorski-get-buffer (profile0)
   (let* ((remote-host (-navorski-profile-get profile0 :remote-host))
-        (screen-name (-navorski-profile-get profile0 :screen-session-name))
-        (profile1 (if screen-name
-                      (-navorski-persistent-term-to-local-term profile)
-                    profile0))
-        (profile (if remote-host
-                     (-navorski-remote-term-to-local-term profile1)
-                   profile1)))
+         (screen-name (-navorski-profile-get profile0 :screen-session-name))
+         (profile1 (if screen-name
+                       (-navorski-persistent-term-to-local-term profile)
+                     profile0))
+         (profile (if remote-host
+                      (-navorski-remote-term-to-local-term profile1)
+                    profile1)))
     (-navorski-get-raw-buffer profile)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -527,7 +525,7 @@ function eterm_set_variables {\n"
 (defun nav/send-string (profile str)
   (with-current-buffer (-navorski-get-buffer profile)
     (let ((inhibit-read-only t))
-         (term-send-raw-string (concat str "\n")))))
+      (term-send-raw-string (concat str "\n")))))
 
 (defun nav/send-region (profile start end)
   (nav/send-string profile (buffer-substring start end)))
@@ -740,7 +738,7 @@ a GNU screen session name."
    (-navorski-remote-term-to-local-term
     (-navorski-persistent-term-to-local-term
      (-navorski-merge-alist '((:kill-buffer-on-stop . t))
-                           profile)))))
+                            profile)))))
 
 ;;;###autoload
 (defun nav/setup-tramp ()


### PR DESCRIPTION
Hello,

This is what I have for now and it works. It raises a few questions that needs to be solved before you can merge this:
- is the name ok?
- as you can see I found a little trick around `:program-args` to run a command after ssh login is successful. This fixes the problem you have currently with `:init-script` that doens't work for ssh connection that requires you to input the password. Would you be interested in refactoring `init-script` around this trick? A neater solution would maybe be to detect `password:` prompt and input them in the minibuffer like TRAMP does.
- when I use remote terminals, very often my emacs becomes laggy and eventually I often have to restart emacs... do you experience the same?
