### PR TITLE
Fix bug when creating more than 2 unnamed terminals

### DIFF
--- a/navorski.el
+++ b/navorski.el
@@ -228,25 +228,21 @@
 ;;; start -navorski-get-buffer-name
 
 (defun -navorski-indexed-buffer-name (buffer-name &optional current-index)
-  (if current-index
+  (if (> current-index 0)
       (format "%s<%s>"
               buffer-name
               current-index)
     (format "%s" buffer-name)))
 
+(defun -navorski-get-unnamed-terminal-count ()
+  (length (--filter (string-match "\*terminal" (buffer-name it))
+                    (buffer-list))))
+
 (defun -navorski-next-buffer-name (&optional buffer-name)
-  (let* ((term-count        (length multi-term-buffer-list))
-         (current-index     nil)
+  (let* ((term-count        (-navorski-get-unnamed-terminal-count))
          (buffer-name       (or buffer-name
                                 navorski-buffer-name)))
-    (while (buffer-live-p
-            (get-buffer
-             (format "*%s*"
-                     (-navorski-indexed-buffer-name
-                      buffer-name
-                      current-index))))
-      (setq current-index (if term-count (1+ term-count) 1)))
-    (-navorski-indexed-buffer-name buffer-name current-index)))
+    (-navorski-indexed-buffer-name buffer-name term-count)))
 
 (defun -navorski-get-buffer-name (profile)
   (let ((buffer-name (format "%s"


### PR DESCRIPTION
Hey @Silex can you take a look...

Currently on my emacs setup, if I do `nav/term` more than twice, it hangs trying to create a new terminal... I modified slightly the code there (stop relying on multi-term list and got the terminal list count via `buffer-list`)

Wanted you to check it out before I merge it to master

Cheers.

Roman.-
