### PR TITLE
No longer use obsolete assoc.el

### DIFF
--- a/navorski.el
+++ b/navorski.el
@@ -26,7 +26,6 @@
 
 (require 'time-stamp)
 (require 'multi-term)
-(require 'assoc)
 (require 'dash)
 
 ;;; Code:
@@ -187,7 +186,7 @@
 ;;;;;;;;;; General
 
 (defun -navorski-profile-get (profile key &optional def)
-  (let ((result (aget profile key)))
+  (let ((result (cdr (assoc key profile))))
     (if (equal result key)
         nil
       result)))
@@ -246,10 +245,10 @@
 
 (defun -navorski-get-buffer-name (profile)
   (let ((buffer-name (format "%s"
-                             (or (aget profile :buffer-name)
-                                 (aget profile :profile-name)
+                             (or (cdr (assq :buffer-name profile))
+                                 (cdr (assq :profile-name profile))
                                  "terminal"))))
-    (if (aget profile :unique)
+    (if (cdr (assq :unique profile))
         buffer-name
       (-navorski-next-buffer-name buffer-name))))
 
@@ -359,7 +358,7 @@
   "Get term buffer."
   (with-temp-buffer
     (let* ((buffer-name  (-navorski-get-buffer-name profile))
-           (term-buffer  (or (and (aget profile :unique)
+           (term-buffer  (or (and (cdr (assq :unique profile))
                                   (get-buffer buffer-name))
                              (-navorski-create-term-buffer profile))))
       (switch-to-buffer term-buffer)

--- a/test/navorski-test.el
+++ b/test/navorski-test.el
@@ -96,9 +96,9 @@
 (ert-deftest navorski-remote-term-to-local-term ()
   (let* ((profile '((:remote-host . "somehost")))
          (result (-navorski-remote-term-to-local-term profile)))
-    (should (string-equal "ssh" (aget result :program-path)))
+    (should (string-equal "ssh" (cdr (assq :program-path result))))
     (should (equal (list "-t" "somehost" "/bin/bash")
-                   (aget result :program-args)))))
+                   (cdr (assq :program-args) result)))))
 
 (ert-deftest navorski-get-buffer-name-test ()
   "Checks that buffer name is being returned correctly"


### PR DESCRIPTION
`assoc.el` was made obsolete eleven years ago [1] and has now been
removed from the `emacs-29` branch [2].

Closes #11.

[1]: https://github.com/emacsmirror/emacs/commit/797e6e88e9cfae3c0
[2]: https://github.com/emacsmirror/emacs/commit/17b3f8d56e254f8f0